### PR TITLE
Feature/remove robot_proxies and robots databases

### DIFF
--- a/mrs/config/configurator.py
+++ b/mrs/config/configurator.py
@@ -65,7 +65,6 @@ class Configurator:
 
     def config_robot(self, robot_id):
         self.register_api('robot', robot_id=robot_id)
-        self.register_store('robot', robot_id=robot_id)
         self.register_robot_id(robot_id)
         self.configure(**self._config_params)
         return self._components

--- a/mrs/config/configurator.py
+++ b/mrs/config/configurator.py
@@ -59,7 +59,6 @@ class Configurator:
 
     def config_robot_proxy(self, robot_id):
         self.register_api('robot_proxy', robot_id=robot_id)
-        self.register_store('robot_proxy', robot_id=robot_id)
         self.register_robot_id(robot_id)
         self.configure(**self._config_params)
         return self._components

--- a/mrs/execution/delay_recovery.py
+++ b/mrs/execution/delay_recovery.py
@@ -17,13 +17,13 @@ class RecoveryMethod:
         return name
 
     def recover(self, timetable, task, task_progress, r_assigned_time, is_consistent):
-        next_task = timetable.get_next_task(task)
+        next_task_id = timetable.get_next_task_id(task)
 
-        if next_task and self.is_next_task_late(timetable, task, next_task, task_progress, r_assigned_time):
-            return next_task
+        if next_task_id and self.is_next_task_late(timetable, task, next_task_id, task_progress, r_assigned_time):
+            return task(task_id=next_task_id)
 
-    def is_next_task_late(self, timetable, task, next_task, task_progress, r_assigned_time):
-        self.logger.debug("Checking if task %s is at risk", next_task.task_id)
+    def is_next_task_late(self, timetable, task, next_task_id, task_progress, r_assigned_time):
+        self.logger.debug("Checking if task %s is at risk", next_task_id)
         mean = 0
         variance = 0
 
@@ -51,7 +51,7 @@ class RecoveryMethod:
         estimated_duration = mean + 2 * round(variance ** 0.5, 3)
         self.logger.debug("Remaining estimated task duration: %s ", estimated_duration)
 
-        node_id, node = timetable.dispatchable_graph.get_node_by_type(next_task.task_id, 'start')
+        node_id, node = timetable.dispatchable_graph.get_node_by_type(next_task_id, 'start')
         latest_start_time_next_task = timetable.dispatchable_graph.get_node_latest_time(node_id)
         self.logger.debug("Latest permitted start time of next task: %s ", latest_start_time_next_task)
 
@@ -59,10 +59,10 @@ class RecoveryMethod:
         self.logger.debug("Estimated start time of next task: %s ", estimated_start_time_of_next_task)
 
         if estimated_start_time_of_next_task > latest_start_time_next_task:
-            self.logger.warning("Task %s is at risk", next_task.task_id)
+            self.logger.warning("Task %s is at risk", next_task_id)
             return True
         else:
-            self.logger.debug("Task %s is not at risk", next_task.task_id)
+            self.logger.debug("Task %s is not at risk", next_task_id)
             return False
 
 

--- a/mrs/execution/dispatcher.py
+++ b/mrs/execution/dispatcher.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from fmlib.models.actions import GoTo
 from mrs.simulation.simulator import SimulatorInterface
 from ropod.structs.task import TaskStatus as TaskStatusConst
+from fmlib.models.tasks import TransportationTask as Task
 
 
 class Dispatcher(SimulatorInterface):
@@ -100,7 +101,8 @@ class Dispatcher(SimulatorInterface):
     def dispatch_tasks(self):
         for robot_id in self.robot_ids:
             timetable = self.timetable_manager.get_timetable(robot_id)
-            task = timetable.get_earliest_task()
+            task_id = timetable.get_earliest_task_id()
+            task = Task.get_task(task_id) if task_id else None
             if task and task.status.status == TaskStatusConst.ALLOCATED:
                 start_time = timetable.get_start_time(task.task_id)
                 if self.is_schedulable(start_time):

--- a/mrs/execution/executor.py
+++ b/mrs/execution/executor.py
@@ -48,8 +48,9 @@ class Executor(RopodPyre):
         payload = msg['payload']
 
         if msg_type == 'TASK':
-            task = Task.from_payload(payload)
-            if self.robot_id in task.assigned_robots:
+            assigned_robots = payload.get("assignedRobots")
+            if self.robot_id in assigned_robots:
+                task = Task.from_payload(payload, save=False)
                 self.logger.debug("Received task %s", task.task_id)
                 self.task = task
 

--- a/mrs/execution/schedule_execution_monitor.py
+++ b/mrs/execution/schedule_execution_monitor.py
@@ -19,7 +19,6 @@ class ScheduleExecutionMonitor(TimetableMonitorBase):
         super().__init__(timetable=timetable, **kwargs)
         self.robot_id = robot_id
         self.timetable = timetable
-        self.timetable.fetch()
         self.scheduler = scheduler
         self.recovery_method = delay_recovery
         self.d_graph_watchdog = kwargs.get("d_graph_watchdog", False)
@@ -80,7 +79,7 @@ class ScheduleExecutionMonitor(TimetableMonitorBase):
             else:
                 self.preempt(task)
 
-    def _update_timepoint(self, task, timetable, r_assigned_time, node_id, task_progress):
+    def _update_timepoint(self, task, timetable, r_assigned_time, node_id, task_progress, store=False):
         is_consistent = True
         try:
             self.timetable.assign_timepoint(r_assigned_time, node_id)
@@ -91,7 +90,7 @@ class ScheduleExecutionMonitor(TimetableMonitorBase):
             is_consistent = False
 
         self.timetable.stn.execute_timepoint(node_id)
-        self._update_edges(task, timetable)
+        self._update_edges(task, timetable, store)
 
         if not self.d_graph_watchdog:
             self.recover(task, task_progress, r_assigned_time, is_consistent)
@@ -115,14 +114,14 @@ class ScheduleExecutionMonitor(TimetableMonitorBase):
 
     def re_allocate(self, task):
         self.logger.info("Trigger re-allocation of task %s", task.task_id)
-        task.update_status(TaskStatusConst.UNALLOCATED)
+        # task.update_status(TaskStatusConst.UNALLOCATED)
         self.timetable.remove_task(task.task_id)
         task_status = TaskStatus(task.task_id, self.robot_id, TaskStatusConst.UNALLOCATED)
         self.send_task_status(task_status)
 
     def preempt(self, task):
         self.logger.info("Trigger preemption of task %s", task.task_id)
-        task.update_status(TaskStatusConst.PREEMPTED)
+        # task.update_status(TaskStatusConst.PREEMPTED)
         self.timetable.remove_task(task.task_id)
         task_status = TaskStatus(task.task_id, self.robot_id, TaskStatusConst.PREEMPTED)
         self.send_task_status(task_status)

--- a/mrs/execution/scheduler.py
+++ b/mrs/execution/scheduler.py
@@ -11,7 +11,6 @@ class Scheduler(object):
     def __init__(self, robot_id, timetable, time_resolution, **kwargs):
         self.robot_id = robot_id
         self.timetable = timetable
-        self.timetable.fetch()
         self.time_resolution = time_resolution
         self.logger = logging.getLogger("mrs.scheduler")
         self.logger.debug("Scheduler initialized %s", self.robot_id)

--- a/mrs/execution/scheduler.py
+++ b/mrs/execution/scheduler.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import numpy as np
 from mrs.exceptions.execution import InconsistentAssignment
 from mrs.exceptions.execution import InconsistentSchedule
-from ropod.structs.status import TaskStatus as TaskStatusConst
 
 
 class Scheduler(object):
@@ -33,14 +32,9 @@ class Scheduler(object):
             try:
                 self.timetable.assign_timepoint(start_time, node_id)
                 start_time = (self.timetable.ztp + timedelta(seconds=start_time)).to_datetime()
-
-                task_schedule = {"start_time": start_time,
-                                 "finish_time": task.finish_time}
-
-                task.update_schedule(task_schedule)
-                task.update_status(TaskStatusConst.SCHEDULED)
+                task.start_time = start_time
                 self.logger.debug("Task %s scheduled to start at %s", task.task_id, task.start_time)
-                return
+                return task
 
             except InconsistentAssignment as e:
                 self.logger.warning("Task %s could not be scheduled at %s", e.task_id, e.assigned_time)

--- a/mrs/messages/d_graph_update.py
+++ b/mrs/messages/d_graph_update.py
@@ -35,8 +35,6 @@ class DGraphUpdate(AsDictMixin):
             timetable.stn = merged_stn
             timetable.dispatchable_graph = merged_dispatchable_graph
 
-        timetable.store()
-
     @staticmethod
     def merge_temporal_graph(previous_graph, new_graph):
         tasks = list()

--- a/mrs/messages/task_announcement.py
+++ b/mrs/messages/task_announcement.py
@@ -41,7 +41,7 @@ class TaskAnnouncement(AsDictMixin):
         attrs = super().to_attrs(dict_repr)
         tasks = list()
         for task_id, task_dict in attrs.get("tasks").items():
-            tasks.append(Task.from_payload(task_dict, constraints=TaskConstraints, request=TransportationRequest))
+            tasks.append(Task.from_payload(task_dict, save=False, constraints=TaskConstraints, request=TransportationRequest))
         attrs.update(tasks=tasks)
         return attrs
 

--- a/mrs/timetable/monitor.py
+++ b/mrs/timetable/monitor.py
@@ -48,7 +48,7 @@ class TimetableMonitorBase:
             task = self.tasks.get(task_status.task_id)
             if task_status.task_status == TaskStatusConst.ONGOING:
                 self.process_task_status_update(task, task_status, timestamp)
-                self.tasks_status[task.task_id] = TaskStatusConst.ALLOCATED
+                self.tasks_status[task.task_id] = task_status.task_status
             if task_status.task_status == TaskStatusConst.COMPLETED:
                 self.process_task_status_update(task, task_status, timestamp)
         except DoesNotExist:

--- a/mrs/timetable/stn_interface.py
+++ b/mrs/timetable/stn_interface.py
@@ -1,7 +1,5 @@
 import uuid
 
-from fmlib.models.tasks import TransportationTask as Task
-from ropod.structs.status import TaskStatus as TaskStatusConst
 from stn.task import Edge
 from stn.task import Task as STNTask
 from stn.task import Timepoint
@@ -30,12 +28,13 @@ class STNInterface:
     def update_task(self, stn_task):
         self.stn.update_task(stn_task)
 
-    def to_stn_task(self, task, travel_duration, insertion_point, earliest_admissible_time):
+    def to_stn_task(self, task, travel_duration, insertion_point, earliest_admissible_time, previous_task_is_frozen):
         travel_edge = Edge(name="travel_time", mean=travel_duration.mean, variance=travel_duration.variance)
         duration_edge = Edge(name="work_time", mean=task.duration.mean, variance=task.duration.variance)
 
         pickup_timepoint = self.get_pickup_timepoint(task, travel_edge, insertion_point)
-        start_timepoint = self.get_start_timepoint(pickup_timepoint, travel_edge, insertion_point, earliest_admissible_time)
+        start_timepoint = self.get_start_timepoint(pickup_timepoint, travel_edge, insertion_point, earliest_admissible_time,
+                                                   previous_task_is_frozen)
         delivery_timepoint = self.get_delivery_timepoint(pickup_timepoint, duration_edge)
 
         edges = [travel_edge, duration_edge]
@@ -46,21 +45,22 @@ class STNInterface:
         stn_task = STNTask(task.task_id, timepoints, edges, pickup_action_id, delivery_action_id)
         return stn_task
 
-    def update_stn_task(self, stn_task, travel_duration, insertion_point, earliest_admissible_time):
+    def update_stn_task(self, stn_task, travel_duration, insertion_point, earliest_admissible_time, previous_task_is_frozen):
         travel_edge = Edge(name="travel_time", mean=travel_duration.mean, variance=travel_duration.variance)
         pickup_timepoint = stn_task.get_timepoint("pickup")
-        start_timepoint = self.get_start_timepoint(pickup_timepoint, travel_edge, insertion_point, earliest_admissible_time)
+        start_timepoint = self.get_start_timepoint(pickup_timepoint, travel_edge, insertion_point, earliest_admissible_time,
+                                                   previous_task_is_frozen)
         stn_task.update_timepoint("start", start_timepoint.r_earliest_time, start_timepoint.r_latest_time)
         return stn_task
 
-    def get_start_timepoint(self, pickup_timepoint, travel_edge, insertion_point, earliest_admissible_time):
+    def get_start_timepoint(self, pickup_timepoint, travel_edge, insertion_point, earliest_admissible_time, previous_task_is_frozen):
         start_timepoint = self.stn.get_prev_timepoint("start", pickup_timepoint, travel_edge)
 
         if insertion_point == 1:
             r_earliest_admissible_time = relative_to_ztp(self.ztp, earliest_admissible_time.to_datetime())
             start_timepoint.r_earliest_time = max(r_earliest_admissible_time, start_timepoint.r_earliest_time)
 
-        if insertion_point > 1 and self.previous_task_is_frozen(insertion_point):
+        if insertion_point > 1 and previous_task_is_frozen:
             r_latest_delivery_time_previous_task = self.get_r_time_previous_task(insertion_point, "delivery", earliest=False)
             start_timepoint.r_earliest_time = max(start_timepoint.r_earliest_time, r_latest_delivery_time_previous_task)
         return start_timepoint
@@ -89,14 +89,6 @@ class STNInterface:
         delivery_timepoint = self.stn.get_next_timepoint("delivery", pickup_timepoint, duration_edge)
         return delivery_timepoint
 
-    def previous_task_is_frozen(self, insertion_point):
-        task_id = self.stn.get_task_id(insertion_point-1)
-        previous_task = Task.get_task(task_id)
-        if previous_task.status.status in [TaskStatusConst.DISPATCHED, TaskStatusConst.ONGOING]:
-            return True
-        return False
-
     def get_r_time_previous_task(self, insertion_point, node_type, earliest=True):
         task_id = self.stn.get_task_id(insertion_point-1)
-        previous_task = Task.get_task(task_id)
-        return self.dispatchable_graph.get_time(previous_task.task_id, node_type, earliest)
+        return self.dispatchable_graph.get_time(task_id, node_type, earliest)

--- a/mrs/utils/datasets.py
+++ b/mrs/utils/datasets.py
@@ -38,7 +38,7 @@ def load_tasks_to_db(dataset_module, dataset_name, **kwargs):
 
         constraints = TransportationTaskConstraints(hard=request.hard_constraints, temporal=temporal)
 
-        task = TransportationTask.create_new(task_id=task_id, request=request.request_id, constraints=constraints)
+        task = TransportationTask.create_new(task_id=task_id, request=request, constraints=constraints)
 
         tasks.append(task)
 


### PR DESCRIPTION
The robot_proxies and robot databases were copies of the FMS database, but included only the information of the corresponding robot. This implementation had the following issues:

- Race conditions while accessing the database when all robot proxies and the FMS start in the same process.  Example: Robot A switches to its database, but before it is done reading or writing, robot B switches the database, causing both robots (A and B) to write the info to the database B.

- Consistency. The information of a robot proxy's database has to be consistent with the information in the FMS database. No sync mechanisms are implemented to make sure this is the case.

- Scalability. The addition of a robot to the fleet creates two additional databases.

- Efficiency. Robot proxies constantly query the database. This is still an issue in the FMS.