### PR TITLE
Rename timepoints and locations to process different types of tasks

### DIFF
--- a/mrs/allocation/bidder.py
+++ b/mrs/allocation/bidder.py
@@ -201,7 +201,7 @@ class Bidder:
     def insert_in(self, insertion_point):
         try:
             task_id = self.timetable.get_task_id(insertion_point)
-            task_status = self.tasks_status.get('task_id')
+            task_status = self.tasks_status.get(task_id)
             if task_status in [TaskStatusConst.DISPATCHED, TaskStatusConst.ONGOING]:
                 self.logger.debug("Task %s was already dispatched "
                                   "Not computing bid for this insertion point %s", task_id, insertion_point)

--- a/mrs/allocation/bidder.py
+++ b/mrs/allocation/bidder.py
@@ -138,7 +138,7 @@ class Bidder:
             if travel_duration is None:
                 self.logger.warning("There was a problem computing the estimated duration between %s and %s "
                                     "Not computing bid for insertion point %s",
-                                    prev_location, task.request.pickup_location, insertion_point)
+                                    prev_location, task.request.start_location, insertion_point)
                 continue
 
             prev_task_is_frozen = self.previous_task_is_frozen(insertion_point)
@@ -160,7 +160,7 @@ class Bidder:
                 if travel_duration is None:
                     self.logger.warning("There was a problem computing the estimated duration between %s and %s "
                                         "Not computing bid for insertion point %s",
-                                        prev_location, next_task.request.pickup_location, insertion_point)
+                                        prev_location, next_task.request.start_location, insertion_point)
                     continue
 
                 prev_task_is_frozen = self.previous_task_is_frozen(insertion_point+1)
@@ -223,7 +223,7 @@ class Bidder:
         else:
             previous_task_id = self.timetable.get_task_id(insertion_point - 1)
             previous_task = self.tasks.get(previous_task_id)
-            previous_location = previous_task.request.delivery_location
+            previous_location = previous_task.request.finish_location
 
         self.logger.debug("Previous location: %s ", previous_location)
         return previous_location
@@ -239,10 +239,10 @@ class Bidder:
         return robot_location
 
     def get_travel_duration(self, task, previous_location):
-        """ Returns time (mean, variance) to go from previous_location to task.pickup_location
+        """ Returns time (mean, variance) to go from previous_location to task.start_location
         """
         try:
-            path = self.planner.get_path(previous_location, task.request.pickup_location)
+            path = self.planner.get_path(previous_location, task.request.start_location)
             mean, variance = self.planner.get_estimated_duration(path)
         except AttributeError:
             self.logger.warning("No planner configured")

--- a/mrs/allocation/bidding_rule.py
+++ b/mrs/allocation/bidding_rule.py
@@ -43,9 +43,9 @@ class BiddingRuleBase:
                           round_id,
                           metrics)
             else:
-                temporal_metric = abs(task.pickup_constraint.earliest_time - task.request.earliest_pickup_time).total_seconds()
+                temporal_metric = abs(task.start_constraint.earliest_time - task.request.earliest_pickup_time).total_seconds()
                 metrics.objective = temporal_metric
-                alternative_start_time = task.pickup_constraint.earliest_time
+                alternative_start_time = task.start_constraint.earliest_time
 
                 bid = Bid(task.task_id,
                           robot_id,

--- a/mrs/allocation/bidding_rule.py
+++ b/mrs/allocation/bidding_rule.py
@@ -43,7 +43,7 @@ class BiddingRuleBase:
                           round_id,
                           metrics)
             else:
-                temporal_metric = abs(task.start_constraint.earliest_time - task.request.earliest_pickup_time).total_seconds()
+                temporal_metric = abs(task.start_constraint.earliest_time - task.request.earliest_start_time).total_seconds()
                 metrics.objective = temporal_metric
                 alternative_start_time = task.start_constraint.earliest_time
 

--- a/mrs/ccu.py
+++ b/mrs/ccu.py
@@ -110,8 +110,8 @@ class CCU:
             task (obj)
 
         """
-        path = self.dispatcher.get_path(task.request.pickup_location,
-                                        task.request.delivery_location)
+        path = self.dispatcher.get_path(task.request.start_location,
+                                        task.request.finish_location)
 
         mean, variance = self.get_task_duration(path)
         task.update_duration(mean, variance)

--- a/mrs/ccu.py
+++ b/mrs/ccu.py
@@ -70,10 +70,19 @@ class CCU:
         self.logger = logging.getLogger("mrs.ccu")
         self.logger.info("Initialized CCU")
 
+        self.tasks = dict()
+        self.pass_on_variables()
+
     def configure(self, **kwargs):
         for key, value in kwargs.items():
             self.logger.debug("Adding %s", key)
             self.__dict__[key] = value
+
+    def pass_on_variables(self):
+        for component_name, component in self.__dict__.items():
+            if hasattr(component, 'tasks'):
+                self.logger.debug("Passing tasks to: %s", component_name)
+                component.tasks = self.tasks
 
     def start_test_cb(self, msg):
         """ Starts test upon reception of start-test message
@@ -98,6 +107,7 @@ class CCU:
         for task in tasks:
             self.add_task_plan(task)
             TaskPerformance.create_new(task_id=task.task_id)
+            self.tasks[task.task_id] = task
 
         self.simulator_interface.start(initial_time)
 

--- a/mrs/exceptions/execution.py
+++ b/mrs/exceptions/execution.py
@@ -23,7 +23,7 @@ class InconsistentAssignment(Exception):
 
         assigned_time (float): time relative to the zero timepoint
         task_id (UUID): id that uniquely identifies the task
-        node_type(str): type of the node (start, pickup, delivery)
+        node_type(str): type of the node (departure, start, finish)
         """
         Exception.__init__(self, assigned_time, task_id, node_type)
         self.assigned_time = assigned_time

--- a/mrs/execution/delay_recovery.py
+++ b/mrs/execution/delay_recovery.py
@@ -1,4 +1,6 @@
 import logging
+
+from fmlib.models import tasks
 from ropod.structs.status import ActionStatus as ActionStatusConst
 
 
@@ -20,7 +22,8 @@ class RecoveryMethod:
         next_task_id = timetable.get_next_task_id(task)
 
         if next_task_id and self.is_next_task_late(timetable, task, next_task_id, task_progress, r_assigned_time):
-            return task(task_id=next_task_id)
+            task_cls = getattr(tasks, type(task).__name__)
+            return task_cls(task_id=next_task_id)
 
     def is_next_task_late(self, timetable, task, next_task_id, task_progress, r_assigned_time):
         self.logger.debug("Checking if task %s is at risk", next_task_id)

--- a/mrs/execution/dispatcher.py
+++ b/mrs/execution/dispatcher.py
@@ -37,6 +37,7 @@ class Dispatcher(SimulatorInterface):
 
         self.robot_ids = list()
         self.d_graph_updates = dict()
+        self.tasks = dict()
 
         self.logger.debug("Dispatcher started")
 
@@ -102,9 +103,9 @@ class Dispatcher(SimulatorInterface):
         for robot_id in self.robot_ids:
             timetable = self.timetable_manager.get_timetable(robot_id)
             task_id = timetable.get_earliest_task_id()
-            task = Task.get_task(task_id) if task_id else None
+            task = self.tasks.get(task_id) if task_id else None
             if task and task.status.status == TaskStatusConst.ALLOCATED:
-                start_time = timetable.get_start_time(task.task_id)
+                start_time = timetable.get_departure_time(task.task_id)
                 if self.is_schedulable(start_time):
                     self.add_pre_task_action(task, robot_id)
                     self.send_d_graph_update(robot_id)

--- a/mrs/execution/dispatcher.py
+++ b/mrs/execution/dispatcher.py
@@ -86,7 +86,7 @@ class Dispatcher(SimulatorInterface):
     def get_pre_task_action(self, task, robot_id):
         pose = self.fleet_monitor.get_robot_pose(robot_id)
         robot_location = self.get_robot_location(pose)
-        path = self.get_path(robot_location, task.request.pickup_location)
+        path = self.get_path(robot_location, task.request.start_location)
         mean, variance = self.get_path_estimated_duration(path)
         action = GoTo.create_new(type="ROBOT-TO-PICKUP", locations=path)
         action.update_duration(mean, variance)

--- a/mrs/messages/task_announcement.py
+++ b/mrs/messages/task_announcement.py
@@ -1,9 +1,7 @@
-from fmlib.models.requests import TransportationRequest
-from fmlib.models.tasks import TransportationTask as Task, TransportationTaskConstraints as TaskConstraints
+from fmlib.models import tasks
+from mrs.utils.as_dict import AsDictMixin
 from ropod.utils.timestamp import TimeStamp
 from ropod.utils.uuid import generate_uuid
-
-from mrs.utils.as_dict import AsDictMixin
 
 
 class TaskAnnouncement(AsDictMixin):
@@ -39,10 +37,12 @@ class TaskAnnouncement(AsDictMixin):
     @classmethod
     def to_attrs(cls, dict_repr):
         attrs = super().to_attrs(dict_repr)
-        tasks = list()
+        tasks_ = list()
         for task_id, task_dict in attrs.get("tasks").items():
-            tasks.append(Task.from_payload(task_dict, save=False, constraints=TaskConstraints, request=TransportationRequest))
-        attrs.update(tasks=tasks)
+            task_type = task_dict.pop("_cls").split('.')[-1]
+            task_cls = getattr(tasks, task_type)
+            tasks_.append(task_cls.from_payload(task_dict, save=False))
+        attrs.update(tasks=tasks_)
         return attrs
 
     @property

--- a/mrs/performance/task.py
+++ b/mrs/performance/task.py
@@ -25,9 +25,9 @@ class TaskPerformanceTracker:
         time_to_allocate = allocation_time
         n_previously_allocated_tasks = len(timetable.get_tasks()) - 1
 
-        start_time = timetable.get_timepoint_constraint(task_id, "start")
-        pickup_time = timetable.get_timepoint_constraint(task_id, "pickup")
-        delivery_time = timetable.get_timepoint_constraint(task_id, "delivery")
+        start_time = timetable.get_timepoint_constraint(task_id, "departure")
+        pickup_time = timetable.get_timepoint_constraint(task_id, "start")
+        delivery_time = timetable.get_timepoint_constraint(task_id, "finish")
 
         return {'time_to_allocate': time_to_allocate,
                 'n_previously_allocated_tasks': n_previously_allocated_tasks,

--- a/mrs/robot_proxy.py
+++ b/mrs/robot_proxy.py
@@ -2,7 +2,7 @@ import argparse
 import logging.config
 
 from fmlib.models.robot import Robot as RobotModel
-from fmlib.models.tasks import TransportationTask as Task
+from fmlib.models import tasks
 from ropod.structs.status import TaskStatus as TaskStatusConst
 
 from mrs.allocation.bidder import Bidder
@@ -56,7 +56,9 @@ class RobotProxy:
         payload = msg['payload']
         assigned_robots = payload.get("assignedRobots")
         if self.robot_id in assigned_robots:
-            task = Task.from_payload(payload, save=False)
+            task_type = payload.pop("_cls").split('.')[-1]
+            task_cls = getattr(tasks, task_type)
+            task = task_cls.from_payload(payload, save=False)
             self.tasks[task.task_id] = task
             self.tasks_status[task.task_id] = TaskStatusConst.DISPATCHED
             self.logger.debug("Received task %s", task.task_id)

--- a/mrs/timetable/monitor.py
+++ b/mrs/timetable/monitor.py
@@ -211,8 +211,8 @@ class TimetableMonitorBase:
 
     def update_pre_task_constraint(self, prev_task, task, timetable):
         self.logger.debug("Update pre_task constraint of task %s", task.task_id)
-        prev_location = prev_task.request.delivery_location
-        path = self.planner.get_path(prev_location, task.request.pickup_location)
+        prev_location = prev_task.request.finish_location
+        path = self.planner.get_path(prev_location, task.request.start_location)
         mean, variance = self.planner.get_estimated_duration(path)
 
         stn_task = timetable.get_stn_task(task.task_id)
@@ -223,7 +223,7 @@ class TimetableMonitorBase:
     def update_robot_poses(self, task):
         for robot_id in task.assigned_robots:
             robot = Robot.get_robot(robot_id)
-            x, y, theta = self.planner.get_pose(task.request.delivery_location)
+            x, y, theta = self.planner.get_pose(task.request.finish_location)
             robot.update_position(x=x, y=y, theta=theta)
 
 
@@ -402,7 +402,7 @@ class TimetableMonitorProxy(TimetableMonitorBase):
             return
 
     def update_robot_pose(self, task):
-        x, y, theta = self.planner.get_pose(task.request.delivery_location)
+        x, y, theta = self.planner.get_pose(task.request.finish_location)
         self.robot.update_position(save=False, x=x, y=y, theta=theta)
 
     def _update_timepoint(self, task, timetable, r_assigned_time, node_id, task_progress, store=False):

--- a/mrs/timetable/monitor.py
+++ b/mrs/timetable/monitor.py
@@ -23,6 +23,7 @@ class TimetableMonitorBase:
         self.d_graph_watchdog = kwargs.get("d_graph_watchdog", False)
         self.api = kwargs.get('api')
         self.logger = logging.getLogger("mrs.timetable.monitor")
+        self.tasks = dict()
 
     def configure(self, **kwargs):
         for key, value in kwargs.items():
@@ -68,20 +69,20 @@ class TimetableMonitorBase:
 
         if task_progress.action_id == first_action_id and \
                 task_progress.action_status.status == ActionStatusConst.ONGOING:
-            node_id, node = timetable.stn.get_node_by_type(task.task_id, 'start')
+            node_id, node = timetable.stn.get_node_by_type(task.task_id, 'departure')
             self._update_timepoint(task, timetable, r_assigned_time, node_id, task_progress)
             try:
                 self.performance_tracker.update_scheduling_metrics(task.task_id, timetable)
             except AttributeError:
                 pass
         else:
-            # An action could be associated to two nodes, e.g., between pickup and delivery there is only one action
+            # An action could be associated to two nodes, e.g., between start and finish there is only one action
             nodes = timetable.stn.get_nodes_by_action(task_progress.action_id)
 
             for node_id, node in nodes:
-                if (node.node_type == 'pickup' and
+                if (node.node_type == 'start' and
                     task_progress.action_status.status == ActionStatusConst.ONGOING) or \
-                        (node.node_type == 'delivery' and
+                        (node.node_type == 'finish' and
                          task_progress.action_status.status == ActionStatusConst.COMPLETED):
                     self._update_timepoint(task, timetable, r_assigned_time, node_id, task_progress)
 
@@ -91,8 +92,8 @@ class TimetableMonitorBase:
 
     def _update_edges(self, task, timetable, store=True):
         nodes = timetable.stn.get_nodes_by_task(task.task_id)
-        self._update_edge(timetable, 'start', 'pickup', nodes)
-        self._update_edge(timetable, 'pickup', 'delivery', nodes)
+        self._update_edge(timetable, 'departure', 'start', nodes)
+        self._update_edge(timetable, 'start', 'finish', nodes)
 
         self.logger.debug("Updated stn: \n %s ", timetable.stn)
         self.logger.debug("Updated dispatchable graph: \n %s", timetable.dispatchable_graph)
@@ -134,8 +135,8 @@ class TimetableMonitorBase:
 
         if task_progress.action_id == first_action_id and \
                 task_progress.action_status.status == ActionStatusConst.ONGOING:
-            self.logger.debug("Task %s start time %s", task.task_id, timestamp)
-            task_schedule = {"start_time": timestamp,
+            self.logger.debug("Task %s departure time %s", task.task_id, timestamp)
+            task_schedule = {"departure_time": timestamp,
                              "finish_time": task.finish_time}
             task.update_schedule(task_schedule)
 
@@ -176,7 +177,8 @@ class TimetableMonitorBase:
             self.logger.warning("Timetable of %s is empty", timetable.robot_id)
             raise EmptyTimetable
 
-        prev_task = timetable.get_previous_task(task)
+        prev_task_id = timetable.get_previous_task_id(task)
+        prev_task = self.tasks.get(prev_task_id)
         earliest_task_id = timetable.get_task_id(position=1)
 
         if task.task_id == earliest_task_id and next_task:
@@ -187,6 +189,8 @@ class TimetableMonitorBase:
         if prev_task and next_task:
             self.update_pre_task_constraint(prev_task, next_task, timetable)
 
+        self.tasks.pop(task.task_id)
+
         if store:
             timetable.store()
         self.logger.debug("STN robot %s: %s", timetable.robot_id, timetable.stn)
@@ -195,17 +199,17 @@ class TimetableMonitorBase:
     @staticmethod
     def _remove_first_task(task, next_task, status, timetable):
         if status == TaskStatusConst.COMPLETED:
-            earliest_time = timetable.stn.get_time(task.task_id, 'delivery', False)
-            timetable.stn.assign_earliest_time(earliest_time, next_task.task_id, 'start', force=True)
+            earliest_time = timetable.stn.get_time(task.task_id, 'finish', False)
+            timetable.stn.assign_earliest_time(earliest_time, next_task.task_id, 'departure', force=True)
         else:
             nodes = timetable.stn.get_nodes_by_task(task.task_id)
             node_id, node = nodes[0]
             earliest_time = timetable.stn.get_node_earliest_time(node_id)
-            timetable.stn.assign_earliest_time(earliest_time, next_task.task_id, 'start', force=True)
+            timetable.stn.assign_earliest_time(earliest_time, next_task.task_id, 'departure', force=True)
 
-        start_next_task = timetable.dispatchable_graph.get_time(next_task.task_id, 'start')
+        start_next_task = timetable.dispatchable_graph.get_time(next_task.task_id, 'departure')
         if start_next_task < earliest_time:
-            timetable.dispatchable_graph.assign_earliest_time(earliest_time, next_task.task_id, 'start', force=True)
+            timetable.dispatchable_graph.assign_earliest_time(earliest_time, next_task.task_id, 'departure', force=True)
 
         timetable.remove_task(task.task_id)
 

--- a/mrs/timetable/stn_interface.py
+++ b/mrs/timetable/stn_interface.py
@@ -32,62 +32,62 @@ class STNInterface:
         travel_edge = Edge(name="travel_time", mean=travel_duration.mean, variance=travel_duration.variance)
         duration_edge = Edge(name="work_time", mean=task.duration.mean, variance=task.duration.variance)
 
-        pickup_timepoint = self.get_pickup_timepoint(task, travel_edge, insertion_point)
-        start_timepoint = self.get_start_timepoint(pickup_timepoint, travel_edge, insertion_point, earliest_admissible_time,
+        start_timepoint = self.get_start_timepoint(task, travel_edge, insertion_point)
+        departure_timepoint = self.get_departure_timepoint(start_timepoint, travel_edge, insertion_point, earliest_admissible_time,
                                                    previous_task_is_frozen)
-        delivery_timepoint = self.get_delivery_timepoint(pickup_timepoint, duration_edge)
+        finish_timepoint = self.get_finish_timepoint(start_timepoint, duration_edge)
 
         edges = [travel_edge, duration_edge]
-        timepoints = [start_timepoint, pickup_timepoint, delivery_timepoint]
-        pickup_action_id = task.plan[0].actions[0].action_id
-        delivery_action_id = task.plan[0].actions[-1].action_id
+        timepoints = [departure_timepoint, start_timepoint, finish_timepoint]
+        start_action_id = task.plan[0].actions[0].action_id
+        finish_action_id = task.plan[0].actions[-1].action_id
 
-        stn_task = STNTask(task.task_id, timepoints, edges, pickup_action_id, delivery_action_id)
+        stn_task = STNTask(task.task_id, timepoints, edges, start_action_id, finish_action_id)
         return stn_task
 
     def update_stn_task(self, stn_task, travel_duration, insertion_point, earliest_admissible_time, previous_task_is_frozen):
         travel_edge = Edge(name="travel_time", mean=travel_duration.mean, variance=travel_duration.variance)
-        pickup_timepoint = stn_task.get_timepoint("pickup")
-        start_timepoint = self.get_start_timepoint(pickup_timepoint, travel_edge, insertion_point, earliest_admissible_time,
+        start_timepoint = stn_task.get_timepoint("start")
+        departure_timepoint = self.get_departure_timepoint(start_timepoint, travel_edge, insertion_point, earliest_admissible_time,
                                                    previous_task_is_frozen)
-        stn_task.update_timepoint("start", start_timepoint.r_earliest_time, start_timepoint.r_latest_time)
+        stn_task.update_timepoint("departure", departure_timepoint.r_earliest_time, departure_timepoint.r_latest_time)
         return stn_task
 
-    def get_start_timepoint(self, pickup_timepoint, travel_edge, insertion_point, earliest_admissible_time, previous_task_is_frozen):
-        start_timepoint = self.stn.get_prev_timepoint("start", pickup_timepoint, travel_edge)
+    def get_departure_timepoint(self, start_timepoint, travel_edge, insertion_point, earliest_admissible_time, previous_task_is_frozen):
+        departure_timepoint = self.stn.get_prev_timepoint("departure", start_timepoint, travel_edge)
 
         if insertion_point == 1:
             r_earliest_admissible_time = relative_to_ztp(self.ztp, earliest_admissible_time.to_datetime())
-            start_timepoint.r_earliest_time = max(r_earliest_admissible_time, start_timepoint.r_earliest_time)
+            departure_timepoint.r_earliest_time = max(r_earliest_admissible_time, departure_timepoint.r_earliest_time)
 
         if insertion_point > 1 and previous_task_is_frozen:
-            r_latest_delivery_time_previous_task = self.get_r_time_previous_task(insertion_point, "delivery", earliest=False)
-            start_timepoint.r_earliest_time = max(start_timepoint.r_earliest_time, r_latest_delivery_time_previous_task)
-        return start_timepoint
+            r_latest_finish_time_previous_task = self.get_r_time_previous_task(insertion_point, "finish", earliest=False)
+            departure_timepoint.r_earliest_time = max(departure_timepoint.r_earliest_time, r_latest_finish_time_previous_task)
+        return departure_timepoint
 
-    def get_pickup_timepoint(self, task, travel_edge, insertion_point):
-        r_earliest_pickup_time = relative_to_ztp(self.ztp, task.start_constraint.earliest_time)
-        r_latest_pickup_time = relative_to_ztp(self.ztp, task.start_constraint.latest_time)
+    def get_start_timepoint(self, task, travel_edge, insertion_point):
+        r_earliest_start_time = relative_to_ztp(self.ztp, task.start_constraint.earliest_time)
+        r_latest_start_time = relative_to_ztp(self.ztp, task.start_constraint.latest_time)
 
         if not task.hard_constraints and insertion_point > 1:
-            pickup_time_window = task.start_constraint.latest_time - task.start_constraint.earliest_time
-            r_earliest_delivery_time_previous_task = self.get_r_time_previous_task(insertion_point, "delivery")
+            start_time_window = task.start_constraint.latest_time - task.start_constraint.earliest_time
+            r_earliest_finish_time_previous_task = self.get_r_time_previous_task(insertion_point, "finish")
 
-            r_earliest_pickup_time = r_earliest_delivery_time_previous_task + travel_edge.mean
-            r_latest_pickup_time = r_earliest_pickup_time + pickup_time_window.total_seconds()
+            r_earliest_start_time = r_earliest_finish_time_previous_task + travel_edge.mean
+            r_latest_start_time = r_earliest_start_time + start_time_window.total_seconds()
 
-            earliest_pickup_time = to_timestamp(self.ztp, r_earliest_pickup_time).to_datetime()
-            latest_pickup_time = to_timestamp(self.ztp, r_latest_pickup_time).to_datetime()
+            earliest_start_time = to_timestamp(self.ztp, r_earliest_start_time).to_datetime()
+            latest_start_time = to_timestamp(self.ztp, r_latest_start_time).to_datetime()
 
-            task.update_start_constraint(earliest_pickup_time, latest_pickup_time, save=False)
+            task.update_start_constraint(earliest_start_time, latest_start_time, save=False)
 
-        pickup_timepoint = Timepoint(name="pickup", r_earliest_time=r_earliest_pickup_time,
-                                     r_latest_time=r_latest_pickup_time)
-        return pickup_timepoint
+        start_timepoint = Timepoint(name="start", r_earliest_time=r_earliest_start_time,
+                                    r_latest_time=r_latest_start_time)
+        return start_timepoint
 
-    def get_delivery_timepoint(self, pickup_timepoint, duration_edge):
-        delivery_timepoint = self.stn.get_next_timepoint("delivery", pickup_timepoint, duration_edge)
-        return delivery_timepoint
+    def get_finish_timepoint(self, start_timepoint, duration_edge):
+        finish_timepoint = self.stn.get_next_timepoint("finish", start_timepoint, duration_edge)
+        return finish_timepoint
 
     def get_r_time_previous_task(self, insertion_point, node_type, earliest=True):
         task_id = self.stn.get_task_id(insertion_point-1)

--- a/mrs/timetable/stn_interface.py
+++ b/mrs/timetable/stn_interface.py
@@ -66,11 +66,11 @@ class STNInterface:
         return start_timepoint
 
     def get_pickup_timepoint(self, task, travel_edge, insertion_point):
-        r_earliest_pickup_time = relative_to_ztp(self.ztp, task.pickup_constraint.earliest_time)
-        r_latest_pickup_time = relative_to_ztp(self.ztp, task.pickup_constraint.latest_time)
+        r_earliest_pickup_time = relative_to_ztp(self.ztp, task.start_constraint.earliest_time)
+        r_latest_pickup_time = relative_to_ztp(self.ztp, task.start_constraint.latest_time)
 
         if not task.hard_constraints and insertion_point > 1:
-            pickup_time_window = task.pickup_constraint.latest_time - task.pickup_constraint.earliest_time
+            pickup_time_window = task.start_constraint.latest_time - task.start_constraint.earliest_time
             r_earliest_delivery_time_previous_task = self.get_r_time_previous_task(insertion_point, "delivery")
 
             r_earliest_pickup_time = r_earliest_delivery_time_previous_task + travel_edge.mean
@@ -79,7 +79,7 @@ class STNInterface:
             earliest_pickup_time = to_timestamp(self.ztp, r_earliest_pickup_time).to_datetime()
             latest_pickup_time = to_timestamp(self.ztp, r_latest_pickup_time).to_datetime()
 
-            task.update_pickup_constraint(earliest_pickup_time, latest_pickup_time)
+            task.update_start_constraint(earliest_pickup_time, latest_pickup_time, save=False)
 
         pickup_timepoint = Timepoint(name="pickup", r_earliest_time=r_earliest_pickup_time,
                                      r_latest_time=r_latest_pickup_time)

--- a/mrs/utils/datasets.py
+++ b/mrs/utils/datasets.py
@@ -2,11 +2,10 @@ import collections
 from datetime import datetime, timedelta
 
 from fmlib.models.requests import TransportationRequest
-from fmlib.models.tasks import TransportationTask, TransportationTaskConstraints
-from fmlib.models.tasks import TimepointConstraint, InterTimepointConstraint, TransportationTemporalConstraints
-from ropod.utils.uuid import generate_uuid
-
+from fmlib.models.tasks import TimepointConstraint, InterTimepointConstraint, TemporalConstraints
+from fmlib.models.tasks import TransportationTask, TaskConstraints
 from mrs.utils.utils import load_yaml_file_from_module
+from ropod.utils.uuid import generate_uuid
 
 
 def load_tasks_to_db(dataset_module, dataset_name, **kwargs):
@@ -34,9 +33,9 @@ def load_tasks_to_db(dataset_module, dataset_name, **kwargs):
         pickup = TimepointConstraint(earliest_time=request.earliest_pickup_time,
                                      latest_time=request.latest_pickup_time)
 
-        temporal = TransportationTemporalConstraints(pickup=pickup, duration=duration)
+        temporal = TemporalConstraints(start=pickup, duration=duration)
 
-        constraints = TransportationTaskConstraints(hard=request.hard_constraints, temporal=temporal)
+        constraints = TaskConstraints(hard=request.hard_constraints, temporal=temporal)
 
         task = TransportationTask.create_new(task_id=task_id, request=request, constraints=constraints)
 


### PR DESCRIPTION
The previous timepoints names were specific to transportation tasks. The new names are more general and apply to other tasks, e.g. navigation tasks.

Renaming:
`start` -> `departure`
`pickup` -> `start`
`delivery` -> `finish`

`departure`: Time at which the robot starts navigating to the start location.
`start`: Time at which the robot arrives at the start location.
`finish`: Time at which the robot finished the last action.

Use task and task request properties to refer to attributes such as:
-  `start_location`
- `finish_location`
- `start_location_level`
- `finish_location_level`
- `earliest_start_time`

Requires:
- https://github.com/kelo-robotics/fmlib/pull/2
- https://github.com/kelo-robotics/mrta_stn/pull/2