### PR TITLE
Fix/allocation round closure

### DIFF
--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -195,24 +195,20 @@ class Auctioneer(SimulatorInterface):
         if not tasks_to_announce:
             return
 
-        closure_time = self.get_closure_time(tasks_to_announce)
-
+        closure_time = self.get_current_time() + self.closure_window
         self.changed_timetable.clear()
 
         self.round = Round(eligible_robots,
                            self.tasks_to_allocate,
-                           n_tasks=len(tasks),
                            closure_time=closure_time,
                            alternative_timeslots=self.alternative_timeslots,
                            simulator=self.simulator)
 
         self.logger.debug("Auctioneer announces tasks %s", [task.task_id for task in tasks_to_announce])
-        self.logger.debug("Eligible robots: %s", eligible_robots.keys())
+        self.logger.debug("Eligible robots: %s", list(eligible_robots.keys()))
 
         task_announcement = TaskAnnouncement(tasks_to_announce, self.round.id, self.timetable_manager.ztp, closure_time)
-
         msg = self.api.create_message(task_announcement)
-
         self.round.start()
         self.api.publish(msg, groups=['TASK-ALLOCATION'])
 

--- a/mrs/allocation/auctioneer.py
+++ b/mrs/allocation/auctioneer.py
@@ -71,12 +71,14 @@ class Auctioneer(SimulatorInterface):
         self.timetable_manager.ztp = time_
 
     def run(self):
-        if self.robots and self.tasks_to_allocate and self.round.finished:
+        if self.tasks_to_allocate and self.round.finished:
+            if not self.robots:
+                self.logger.warning("There are no robots registered on the FMS."
+                                    "Do not announcing tasks for allocation.")
+                return
+
             tasks = list(self.tasks_to_allocate.values())
-            self.check_tasks_validity(tasks)
-            tasks_to_announce = self.get_tasks_to_announce(tasks)
-            if tasks_to_announce:
-                self.announce_tasks(tasks_to_announce)
+            self.announce_tasks(tasks)
 
         if self.round.opened and self.round.time_to_close():
             try:
@@ -169,58 +171,70 @@ class Auctioneer(SimulatorInterface):
         self.round.finish()
 
     def announce_tasks(self, tasks):
+        tasks_to_announce = list()
+        eligible_robots = list()
+        for task in tasks:
+            self.check_task_validity(task)
+            eligible_robots_for_task = self.get_eligible_robots(task)
+            if eligible_robots_for_task:
+                eligible_robots.extend([robot_id for robot_id in eligible_robots_for_task
+                                        if robot_id not in eligible_robots])
+                if task not in tasks_to_announce:
+                    tasks_to_announce.append(task)
+            else:
+                self.logger.warning("No eligible robots for task. "
+                                    "Task %s is not announced.", task.task_id)
+        if not tasks_to_announce:
+            return
+
         closure_time = self.get_closure_time(tasks)
 
         self.changed_timetable.clear()
 
-        self.round = Round(list(self.robots.keys()),
+        self.round = Round(eligible_robots,
                            self.tasks_to_allocate,
                            n_tasks=len(tasks),
                            closure_time=closure_time,
                            alternative_timeslots=self.alternative_timeslots,
                            simulator=self.simulator)
 
-        task_announcement = TaskAnnouncement(tasks, self.round.id, self.timetable_manager.ztp, closure_time)
+        self.logger.debug("Auctioneer announces tasks %s", [task.task_id for task in tasks_to_announce])
+        self.logger.debug("Eligible robots: %s", eligible_robots)
+
+        task_announcement = TaskAnnouncement(tasks_to_announce, self.round.id, self.timetable_manager.ztp, closure_time)
 
         msg = self.api.create_message(task_announcement)
-
-        self.logger.debug("Auctioneer announces tasks %s", [task.task_id for task in tasks])
 
         self.round.start()
         self.api.publish(msg, groups=['TASK-ALLOCATION'])
 
-    def check_tasks_validity(self, tasks):
-        for task in tasks:
-            if not self.is_valid_time(task.start_constraint.latest_time):
-                if self.alternative_timeslots:
-                    task.hard_constraints = False
-                    self.logger.warning("Setting soft constraints for task %s", task.task_id)
-                else:
-                    self.logger.warning("Task %s cannot not be allocated at its given temporal constraints",
-                                        task.task_id)
-                    task.update_status(TaskStatusConst.PREEMPTED)
-                    self.tasks_to_allocate.pop(task.task_id)
+    def get_eligible_robots(self, task):
+        capable_robots = self.get_capable_robots(task)
+        if task.request.eligible_robots:
+            eligible_robots = [robot_id for robot_id in capable_robots if robot_id in task.request.eligible_robots]
+        else:
+            eligible_robots = capable_robots
+        self.logger.debug("Eligible robots for task %s: %s", task.task_id, eligible_robots)
+        return eligible_robots
 
-    def get_tasks_to_announce(self, tasks):
-        tasks_to_announce = list()
-        for task in tasks:
-            if not task.request.eligible_robots or \
-                    (task.request.eligible_robots and
-                     any(robot_id in task.request.eligible_robots for robot_id in self.robots.keys())):
+    def get_capable_robots(self, task):
+        capable_robots = list()
+        for robot_id, robot in self.robots.items():
+            if all(i in robot.capabilities for i in task.capabilities):
+                capable_robots.append(robot_id)
+        self.logger.debug("Capable robots for task %s: %s", task.task_id, capable_robots)
+        return capable_robots
 
-                for robot_id, robot in self.robots.items():
-                    if all(i in robot.capabilities for i in task.capabilities) and task not in tasks_to_announce:
-                        tasks_to_announce.append(task)
-
-                if not tasks_to_announce:
-                    self.logger.warning("None of the robots has the capabilities required by the task."
-                                        "Task %s is not announced.", task.task_id)
-
+    def check_task_validity(self, task):
+        if not self.is_valid_time(task.start_constraint.latest_time):
+            if self.alternative_timeslots:
+                task.hard_constraints = False
+                self.logger.warning("Setting soft constraints for task %s", task.task_id)
             else:
-                self.logger.warning("None of the eligible_robots in the task-request are available." 
-                                    "Task %s is not announced.", task.task_id)
-
-        return tasks_to_announce
+                self.logger.warning("Task %s cannot not be allocated at its given temporal constraints",
+                                    task.task_id)
+                task.update_status(TaskStatusConst.PREEMPTED)
+                self.tasks_to_allocate.pop(task.task_id)
 
     def get_closure_time(self, tasks):
         earliest_task = Task.get_earliest_task(tasks)

--- a/mrs/allocation/round.py
+++ b/mrs/allocation/round.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from mrs.exceptions.allocation import AlternativeTimeSlot
 from mrs.exceptions.allocation import NoAllocation
-from mrs.messages.bid import NoBid, BiddingRobot
+from mrs.messages.bid import NoBid
 from mrs.simulation.simulator import SimulatorInterface
 from ropod.utils.uuid import generate_uuid
 
@@ -20,12 +20,12 @@ class RoundBidder:
 
 class Round(SimulatorInterface):
 
-    def __init__(self, robot_ids, tasks_to_allocate, **kwargs):
+    def __init__(self, eligible_robots, tasks_to_allocate, **kwargs):
         simulator = kwargs.get('simulator')
         super().__init__(simulator)
 
         self.logger = logging.getLogger('mrs.auctioneer.round')
-        self.robot_ids = robot_ids
+        self.eligible_robots = eligible_robots
         self.tasks_to_allocate = tasks_to_allocate
 
         self.n_tasks = kwargs.get('n_tasks')
@@ -37,7 +37,6 @@ class Round(SimulatorInterface):
         self.opened = False
         self.received_bids = dict()
         self.received_no_bids = dict()
-        self.bidding_robots = {robot_id: BiddingRobot(robot_id) for robot_id in self.robot_ids}
         self.start_time = datetime.now().timestamp()
         self.time_to_allocate = None
 
@@ -84,7 +83,7 @@ class Round(SimulatorInterface):
                     self.update_task_bid(bid, self.received_bids[bid.task_id]):
                 self.received_bids[bid.task_id] = bid
 
-        self.bidding_robots[bid.robot_id].update(bid)
+        self.eligible_robots[bid.robot_id].update(bid)
 
     @staticmethod
     def update_task_bid(new_bid, old_bid):
@@ -102,11 +101,11 @@ class Round(SimulatorInterface):
 
     def all_robots_placed_bid(self):
         bidding_robots = 0
-        for robot_id, bidding_robot in self.bidding_robots.items():
-            if bidding_robot.placed_bid(self.n_tasks):
+        for robot_id, eligible_robot in self.eligible_robots.items():
+            if eligible_robot.placed_bid():
                 bidding_robots += 1
 
-        if bidding_robots == len(self.robot_ids):
+        if bidding_robots == len(self.eligible_robots):
             return True
         return False
 

--- a/mrs/allocation/round.py
+++ b/mrs/allocation/round.py
@@ -28,7 +28,6 @@ class Round(SimulatorInterface):
         self.eligible_robots = eligible_robots
         self.tasks_to_allocate = tasks_to_allocate
 
-        self.n_tasks = kwargs.get('n_tasks')
         self.closure_time = kwargs.get('closure_time')
         self.alternative_timeslots = kwargs.get('alternative_timeslots', False)
         self.id = generate_uuid()

--- a/mrs/config/default/config.yaml
+++ b/mrs/config/default/config.yaml
@@ -35,7 +35,7 @@ delay_recovery:
 d_graph_watchdog: False
 
 auctioneer:
-  closure_window: 1 # minutes
+  closure_window: 30 # seconds
   alternative_timeslots: False
 
 dispatcher:

--- a/mrs/messages/bid.py
+++ b/mrs/messages/bid.py
@@ -155,9 +155,10 @@ class AllocationInfo(AsDictMixin):
         return attrs
 
 
-class BiddingRobot:
+class EligibleRobot:
     def __init__(self, robot_id):
         self.robot_id = robot_id
+        self.tasks = list()  # tasks for which the robot can place a bid
         self.bids = list()
         self.no_bids = list()
 
@@ -166,13 +167,16 @@ class BiddingRobot:
         to_print += "{}, bids: {}, no_bids:{}".format(self.robot_id, self.bids, self.no_bids)
         return to_print
 
+    def add_task(self, task):
+        self.tasks.append(task)
+
     def update(self, bid):
         if isinstance(bid, NoBid):
             self.no_bids.append(bid)
         else:
             self.bids.append(bid)
 
-    def placed_bid(self, n_tasks):
-        if len(self.bids) == 1 or len(self.no_bids) == n_tasks:
+    def placed_bid(self):
+        if len(self.bids) == 1 or len(self.no_bids) == len(self.tasks):
             return True
         return False


### PR DESCRIPTION
The current allocation round will remain open until the the `closure_time`:

```
closure_time = earliest_task.start_constraint.earliest_time - self.closure_window
```

where `closure_window` is a parameter in the config file (its current value is 30 seconds)

The `closure_time` is s x seconds before the earliest announced task

An allocation round stays open until:
1. the `closure_time`, or
2. until all robots in the fleet have placed a bid

Case (1) potentially leaves little time for allocating the remaining tasks. A new allocation round has to open per allocation (only one task is allocated per round). When the second earliest task to allocate has the same `earliest_start_time` as the first earliest task, the second earliest task will have an invalid (time in the past) `earliest_start_time` when the second allocation round opens.

Since there might be communication issues, not all robots in the fleet might be able to place a bid, hence the `closure_time` was introduced. 

The current implementation waits until all robots in the list of robot ids in the FMS config file have sent a bid OR until the `closure_time` is the current time. However:

The meaning of the list of robot ids in the config file changed. Before, all robots on the list were considered to be up and running. Now, the robots in the list are the known robots, but not necessarily the registered robots. Robots send an availability-status message at startup. The FMS registers a robot upon reception of this message.

Changes proposed:

- The FMS could get a list of the `eligible_robots` per task. A task_request includes a list of `eligible_robots`. In case the list is empty, all registered robots are eligible, provided that they have the required capabilities for the task. The `eligible_robots` for an allocation round is the set of `eligible_robots` for all tasks in the task-announcement.

In this way, the Auctioneer could have a dictionary of `eligible_robots`: robots from which a bid is expected in an allocation round.

An allocation round stays open until:
1. a predefined time after the round opened (determined by the `closure_window`)
2. until all robots in the dict of `eligible_robots` have placed a bid

A round will only open if there are tasks for which there are `eligible_robots` 